### PR TITLE
Add html suffix to Setup link

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,5 +10,5 @@ use shell commands to find and manipulate data.
 
 > ## Prerequisites
 >
-> To complete this lesson, you will need a UNIX-like shell environment -see [Setup](http://librarycarpentry.github.io/lc-shell/setup/). You will also need to download the file **[shell-lesson.zip](https://raw.githubusercontent.com/librarycarpentry/lc-shell/gh-pages/data/shell-lesson.zip)** from GitHub to your *desktop* and extract it there (once you have unzipped/extracted the file, you should end up with a folder called "shell-lesson").
+> To complete this lesson, you will need a UNIX-like shell environment -see [Setup](https://librarycarpentry.github.io/lc-shell/setup.html). You will also need to download the file **[shell-lesson.zip](https://raw.githubusercontent.com/librarycarpentry/lc-shell/gh-pages/data/shell-lesson.zip)** from GitHub to your *desktop* and extract it there (once you have unzipped/extracted the file, you should end up with a folder called "shell-lesson").
 {: .prereq}


### PR DESCRIPTION
Setup link for shell lesson in Prerequisites section does not work. Link for Setup in top navigation bar does. I replaced the former with the latter.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
