### PR TITLE
Fix: remove extra colon in exercise

### DIFF
--- a/_episodes/04-loops.md
+++ b/_episodes/04-loops.md
@@ -119,7 +119,7 @@ The shell itself doesn't care what the variable is called.
 > > ```
 > > for file in *.txt
 > > do
-> > 	echo $file:
+> > 	echo $file
 > > 	head -n 1 $file
 > > 	tail -n 1 $file
 > > done


### PR DESCRIPTION
There isn't a colon in the version with blanks, only in the exercise. It should either be both places or none.

While it's not really wrong to have a colon there, I think it increases the mental load of the exercise for no good reason, so I removed it.