### PR TITLE
Change results for "Jo" "Meg" "Beth" "Amy"

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -760,13 +760,13 @@ $ for name in "Jo" "Meg" "Beth" "Amy"
 
 ~~~
 Jo
-18877
+1528
 Meg
-8314
+685
 Beth
-5684
+463
 Amy
-7933
+643
 ~~~
 {: .output}
 


### PR DESCRIPTION
When running this loop:
$ for name in "Jo" "Meg" "Beth" "Amy"
> do
> echo $name
> grep $name littlewomen.txt | wc -l
> done

The results are consistently: 
Jo
1528
Meg
685
Beth
463
Amy
643

The file is still the one from http://www.gutenberg.org/cache/epub/514/pg514.txt


