### PR TITLE
Wrap variable substitutions in "-quotes to avoid real-world problems

### DIFF
--- a/_episodes/04-loops.md
+++ b/_episodes/04-loops.md
@@ -36,8 +36,8 @@ Now we will use a loop to create a backup version of those files. Accordingly, w
 ~~~
 $ for filename in *.doc
 > do
->    echo $filename
->    cp $filename backup_$filename
+>    echo "$filename"
+>    cp "$filename" backup_"$filename"
 > done
 ~~~
 {: .bash}
@@ -54,13 +54,24 @@ When the shell sees the keyword `for`,
 it knows to repeat a command (or group of commands) once for each thing `in` a list.
 For each iteration,
 the name of each thing is sequentially assigned to
-the **variable** and the commands inside the loop are executed before moving on to
+the **loop variable** and the commands inside the loop are executed before moving on to
 the next thing in the list.
 Inside the loop,
 we call for the variable's value by putting `$` in front of it.
 The `$` tells the shell interpreter to treat
 the **variable** as a variable name and substitute its value in its place,
 rather than treat it as text or an external command.
+
+> ## Double-quoting variable substitutions
+>
+> Because real-world filenames often contain white-spaces,
+> we wrap `$filename` in double quotes (`"`). If we didn't, the
+> shell would treat the white-space within a filename a separator
+> between two different filesnames, which usually results in errors.
+> Therefore, it's best to generally safer to use `"$..."` unless
+> you are absolutely sure that no elements with white-space can ever
+> enter your loop variable (such as in [episode 5]({{ page.root }}/05-counting-mining/index.html#using-a-loop-to-count-words)).
+{: .callout}
 
 In this example, the list is four filenames: 'a.doc', 'b.doc', 'c.doc', and 'd.doc'
 Each time the loop iterates, it will assign a file name to the variable `filename`
@@ -108,9 +119,9 @@ The shell itself doesn't care what the variable is called.
 > ```
 > ___ file in *.txt
 > __
-> 	echo _file
-> 	head -n 1 _____
-> 	____ __ _ _____
+> 	echo "_file"
+> 	head -n 1 _______
+> 	____ __ _ _______
 > ____
 > ```
 > {: .bash}
@@ -119,9 +130,9 @@ The shell itself doesn't care what the variable is called.
 > > ```
 > > for file in *.txt
 > > do
-> > 	echo $file
-> > 	head -n 1 $file
-> > 	tail -n 1 $file
+> > 	echo "$file"
+> > 	head -n 1 "$file"
+> > 	tail -n 1 "$file"
 > > done
 > > ```
 > > {: .bash}
@@ -151,9 +162,9 @@ This is our first look at loops. We will run another loop in the
 > > # This script loops through txt files, returns the file name, first line, and last line of the file
 > > for file in *.txt
 > > do
-> > 	echo $file
-> > 	head -n 1 $file
-> > 	tail -n 1 $file
+> > 	echo "$file"
+> > 	head -n 1 "$file"
+> > 	tail -n 1 "$file"
 > > done
 > > ```
 > > {: .bash}

--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -772,6 +772,36 @@ What is happening the the loop?
 + The output from the `grep` command is redirected with the pipe, `|` (without the pipe and the rest of the line, the output from `grep` would print directly to the screen)
 + `wc -l` counts the number of _lines_ (because we used the `-l` flag) sent from `grep`. Because `grep` only returned lines that contained the value stored in `$name`, `wc -l` corresponds to the number of occurances of each girl's name.
 
+> ## Why are the variables double-quoted here?
+>
+> a) In [episode 4]({{ page.root }}/04-loops/index.html)) we learned to
+> use `"$..."` as a safeguard against white-space being misinterpreted.
+> Why _could_ we omit the `"`-quotes in the above example?
+> 
+> b) What happens if you add `"Louisa May Alcott"` to the first line of
+> the loop and remove the `"` from `$name` in the loop's code?
+> 
+>> ## Solutions
+>> 
+>> a) Because we are explicitly listing the names after `in`,
+>> and those contain no white-space. However, for consistency
+>> it's better to use rather once too often than once too rarely.
+>> 
+>> b) Without `"`-quoting `$name`, the last loop will try to execute
+>> `grep Louisa May Alcott littlewomen.txt`. `grep` interprets only the
+>> first word as the search pattern, but `May` and `Alcott` as filenames.
+>> This produces two errors and a possibly untrustworthy count:
+>> ~~~
+>> ...
+>> Louisa May Alcott
+>> grep: May: No such file or directory
+>> grep: Alcott: No such file or directory
+>> 4
+>> ~~~
+>> {: .bash}
+> {: .solution}
+{: .challenge}
+
 > ## Selecting columns from our article dataset
 > When you receive data it will often contain more columns or variables than you need for your work. If you want to select only the columns you need for your analysis, you can use the `cut` command to do so. `cut` is a tool for extracting sections from a file. For instance, say we want to retain only the `Creator`, `Journal`, `ISSN`, and `Title` columns from our article data. With `cut` we'd:
 >~~~

--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -747,8 +747,8 @@ and count the number of times it appears. The results will print to the screen.
 ~~~
 $ for name in "Jo" "Meg" "Beth" "Amy"
 > do
->    echo $name
->    grep $name littlewomen.txt | wc -l
+>    echo "$name"
+>    grep "$name" littlewomen.txt | wc -l
 > done
 ~~~
 
@@ -767,8 +767,8 @@ Amy
 {: .output}
 
 What is happening the the loop?  
-+ `echo $name` is printing the current value of `$name`
-+ `grep $name littlewomen.txt` finds each line that contains the value stored in `$name`
++ `echo "$name"` is printing the current value of `$name`
++ `grep "$name" littlewomen.txt` finds each line that contains the value stored in `$name`
 + The output from the `grep` command is redirected with the pipe, `|` (without the pipe and the rest of the line, the output from `grep` would print directly to the screen)
 + `wc -l` counts the number of _lines_ (because we used the `-l` flag) sent from `grep`. Because `grep` only returned lines that contained the value stored in `$name`, `wc -l` corresponds to the number of occurances of each girl's name.
 

--- a/fig/shell_script_for_loop_flow_chart.svg
+++ b/fig/shell_script_for_loop_flow_chart.svg
@@ -658,7 +658,7 @@
        x="28.124039"
        y="60.941799"
        style="font-size:10.99998951px"
-       id="tspan16698">    echo cp "$filename" original-"$filename"</tspan><tspan
+       id="tspan16698">    echo cp "$filename" backup_"$filename"</tspan><tspan
        sodipodi:role="line"
        x="28.124039"
        y="74.691788"
@@ -755,7 +755,7 @@
        id="tspan16738"
        x="557.32788"
        y="275.51794"
-       style="font-size:10.99998951px">cp input-1.dat original-input-1.dat</tspan></text>
+       style="font-size:10.99998951px">cp input-1.dat backup_input-1.dat</tspan></text>
 <text
      sodipodi:linespacing="125%"
      id="text16740"
@@ -815,7 +815,7 @@
        y="306.69904"
        x="557.32788"
        id="tspan16762"
-       sodipodi:role="line">cp input-2.dat original-input-2.dat</tspan></text>
+       sodipodi:role="line">cp input-2.dat backup_input-2.dat</tspan></text>
 <text
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;font-size:11.99998856px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -827,7 +827,7 @@
        id="tspan16766"
        x="556.26685"
        y="337.88016"
-       style="font-size:10.99998951px">cp input-3.dat original-input-3.dat</tspan></text>
+       style="font-size:10.99998951px">cp input-3.dat backup_input-3.dat</tspan></text>
 <text
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;font-size:10.99998951px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"

--- a/fig/shell_script_for_loop_flow_chart.svg
+++ b/fig/shell_script_for_loop_flow_chart.svg
@@ -658,7 +658,7 @@
        x="28.124039"
        y="60.941799"
        style="font-size:10.99998951px"
-       id="tspan16698">    echo cp $filename original-$filename</tspan><tspan
+       id="tspan16698">    echo cp "$filename" original-"$filename"</tspan><tspan
        sodipodi:role="line"
        x="28.124039"
        y="74.691788"


### PR DESCRIPTION
I recently discovered [ShellCheck(.net)](https://www.shellcheck.net/) and used it to clean up some of my scripts. Highly recommended!

The 1 IMHO [critical advice from it is about always using `"$filename"`](https://github.com/koalaman/shellcheck/wiki/SC2046) because in the real-world, people use whitespaces in filenames and that would break most `cmd $filename` examples.

This PR upgrades our examples to this good practice, adds a challenge about it and adjusts some related wording.