### PR TITLE
Add -w to solution to excercise

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -626,7 +626,7 @@ Pair up with your neighbor and work on these exercises:
 >
 > > ## Solution
 > > ~~~
-> > $ grep hero *.tsv
+> > $ grep -w hero *.tsv
 > > ~~~
 > > {: .bash}
 > {: .solution}


### PR DESCRIPTION
Shouldn't the answer to this excercise be grep -w hero *.tsv to get every instance of the word hero that is case insensitive?

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
