### PR TITLE
uniq shoud be used with sort

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -722,15 +722,14 @@ Pair up with your neighbor and work on these exercises:
 {: .challenge}
 
 > ## Finding unique values
-> If you pipe something to the `uniq` command, it will filter out duplicate lines
-> and only return unique ones. Try piping the output from the command in the last exercise
-> to `uniq` and then to `wc -l` to count the number of unique ISSN values.
+> If you pipe something to the `uniq` command, it will filter out adjacent duplicate lines. In order for the 'uniq' command to only return unique values though, it needs to be used with the 'sort' command. Try piping the output from the command in the last exercise
+> to `sort` and then piping these results to 'uniq' and then `wc -l` to count the number of unique ISSN values.
 > Note: This exercise requires the `-o` flag. See the callout box "Invalid option -- o?"
 > above.
 >
 > > ## Solution
 > > ~~~
-> > $ grep -Eo '\d{4}-\d{4}' 2014-01_JA.tsv | uniq | wc -l
+> > $ grep -Eo '\d{4}-\d{4}' 2014-01_JA.tsv | sort | uniq | wc -l
 > > ~~~
 > > {: .bash}
 > {: .solution}


### PR DESCRIPTION
The uniq command usually needs to be used with the sort command to return uniq values, since the uniq command only dedupes values adjacent to each other. I added some language to delineate this, as well as rewrote the solution to this excercise.

