### PR TITLE
Add -wo to Little Women loop

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -789,7 +789,7 @@ and count the number of times it appears. The results will print to the screen.
 $ for name in "Jo" "Meg" "Beth" "Amy"
 > do
 >    echo "$name"
->    grep "$name" littlewomen.txt | wc -l
+>    grep -wo "$name" littlewomen.txt | wc -l
 > done
 ~~~
 
@@ -797,13 +797,13 @@ $ for name in "Jo" "Meg" "Beth" "Amy"
 
 ~~~
 Jo
-1528
+1355
 Meg
-685
+683
 Beth
-463
+459
 Amy
-643
+645
 ~~~
 {: .output}
 


### PR DESCRIPTION
If you do not add the -w to the grep command in this loop, it will give you false results, It will return results for all the strings with Jo, Meg, Beth, and Amy in them. This is particularly glaring with "Jo" since it picks up John and other strings with Jo in them. I added the -o to the loop as that will pick up if the string if it appears more than once in a line.  I changed the results to reflect what I got when I ran this loop.

