### PR TITLE
changed file name to reflect columns used

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -867,7 +867,7 @@ What is happening the the loop?
 > Above we used `cut` and the `-f` flag to indicate which columns we want to retain. `cut` works on tab delimited files by default. We can use the flag `-d` to change this to a comma, or semicolon or another delimiter.
 > If you are unsure of your column position and the file has headers on the first line, we can use `head -n 1 <filename>` to print those out.
 > ### Now your turn
->Select the columns `Issue`, `Volume`, `Language`, `Publisher` and direct the output into a new file. You can name it something like `2014-01_JA_ivjlp.tsv`.
+>Select the columns `Issue`, `Volume`, `Language`, `Publisher` and direct the output into a new file. You can name it something like `2014-01_JA_ivlp.tsv`.
 >> ## Solution
 >> First, let's see where our desired columns are:
 >>
@@ -884,11 +884,11 @@ What is happening the the loop?
 >>Ok, now we know `Issue` is column 3, `Volume` 4, `Language` 11, and `Publisher` 12.
 >> We use these positional column numbers to construct our `cut` command:
 >>```
->> cut -f 3,4,11,12 2014-01_JA.tsv > 2014-01_JA_ivjlp.tsv
+>> cut -f 3,4,11,12 2014-01_JA.tsv > 2014-01_JA_ivlp.tsv
 >>```
 >> We can confirm this worked by running head on the file:
 >>```
->>head 2014-01_JA_ivjlp.tsv
+>>head 2014-01_JA_ivlp.tsv
 >>```
 >>~~~
 >>Issue	Volume	Language	Publisher


### PR DESCRIPTION
I changed the file name 2014-01_JA_ivjlp.tsv to 2014-01_JA_ivlp.tsv to reflect that Journal was not being searched for, and it was just Issue, Volume, Language, and Publisher, hence ivlp.

