### PR TITLE
Use numerical sort for word counts in options 1 and 3

### DIFF
--- a/_episodes/06-free-text.md
+++ b/_episodes/06-free-text.md
@@ -133,7 +133,7 @@ Open the `gulliver-clean.txt` in a text editor. Note how the text has been trans
 We are now ready to pull the text apart.
 
 ~~~
-$ tr ' ' '\n' < gulliver-clean.txt | sort | uniq -c | sort -r > gulliver-final.txt
+$ tr ' ' '\n' < gulliver-clean.txt | sort | uniq -c | sort -nr > gulliver-final.txt
 ~~~
 {: .bash}
 
@@ -345,7 +345,7 @@ Open the `diary-clean.txt` in a text editor. Note how the text has been transfor
 We are now ready to pull the text apart.
 
 ~~~
-$ tr ' ' '\n' < diary-clean.txt | sort | uniq -c | sort -r > diary-final.txt
+$ tr ' ' '\n' < diary-clean.txt | sort | uniq -c | sort -nr > diary-final.txt
 ~~~
 {: .bash}
 


### PR DESCRIPTION
Regarding episode 6, “Working with free text”: having prefixed all lines with word counts, it makes more sense to perform a numerical sort than a lexical one. This change brings options 1 and 3 into line with option 2.
