### PR TITLE
Update 03-working-with-files-and-folders.md

### DIFF
--- a/_episodes/03-working-with-files-and-folders.md
+++ b/_episodes/03-working-with-files-and-folders.md
@@ -89,6 +89,7 @@ total 33M
 -rw-r--r-- 1 riley staff 582K Feb  2 2017  33504-0.txt
 -rw-r--r-- 1 riley staff 598K Jan 31 2017  829-0.txt
 -rw-rw-r-- 1 riley staff  18K Feb 22 2017  diary.html
+drwxr-xr-x 1 riley staff  64B Feb 22 2017  firstdir
 ~~~
 {: .output}
 


### PR DESCRIPTION
The directory 'firstdir' created in the exercise at the beginning of the episode was not shown in the output of the 'ls -lh' command in the exercise directly following it. Added the 'firstdir' to the output of 'ls -lh' to reflect what the student would see.