### PR TITLE
Remove negative reference to vim in instructor notes

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -149,7 +149,6 @@ as long as learners using Windows do not run into roadblocks such as:
 -   Running a text editor from the command line can be
     the biggest stumbling block during the entire lesson:
     many will try to run the same editor as the instructor
-    (which may leave them trapped in the awful nether hell that is Vim),
     or will not know how to navigate to the right directory
     to save their file,
     or will run a word processor rather than a plain text editor.


### PR DESCRIPTION
A small edit to remove negative reference to the Vim text editor. 

I am sure this reference to vim was intended as tongue-in-cheek but it might convey to instructors or learners that Vim is unusable or not worth exploring. Whilst there is a big learning curve to using vim, it can also be very useful to have at least some familiarity with it when editing in remote machines via ssh etc and for some people, it can become a powerful text editing environment. 