### PR TITLE
Add the word whole to challenge question

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -620,7 +620,7 @@ Pair up with your neighbor and work on these exercises:
 
 > ## Case sensitive search
 > Search for all case sensitive instances of
-> a word you choose in all four derived `.tsv` files in this directory.
+> a whole word you choose in all four derived `.tsv` files in this directory.
 > Print your results to the shell.
 >
 > > ## Solution


### PR DESCRIPTION
The two challenge excercises are the same in their wording about the grep function, but one solution uses the -w flag and one doesn't. We either need to add the -w flag to the second challenge or add the word "whole" to the first challenge.

