### PR TITLE
Remove word "simply"

### DIFF
--- a/_episodes/03-working-with-files-and-folders.md
+++ b/_episodes/03-working-with-files-and-folders.md
@@ -337,7 +337,7 @@ $ ls
 {: .challenge}
 
 > ## Using the `echo` command
-> The `echo` command simply prints out a text you specify. Try it out: `echo "Library Carpentry is awesome!"`.
+> The `echo` command prints out a text you specify. Try it out: `echo "Library Carpentry is awesome!"`.
 > Interesting, isn't it?
 >
 > You can also specify a variable, for instance `NAME=` followed by your name.


### PR DESCRIPTION
Remove the word simply, as we don't want to imply that printing an output to the terminal screen is a simple operation.

