### PR TITLE
Avoid problem with active bang in zsh

### DIFF
--- a/_episodes/03-working-with-files-and-folders.md
+++ b/_episodes/03-working-with-files-and-folders.md
@@ -337,7 +337,7 @@ $ ls
 {: .challenge}
 
 > ## Using the `echo` command
-> The `echo` command simply prints out a text you specify. Try it out: `echo "Library Carpentry is awesome!"`.
+> The `echo` command simply prints out a text you specify. Try it out: `echo 'Library Carpentry is awesome!'`.
 > Interesting, isn't it?
 >
 > You can also specify a variable, for instance `NAME=` followed by your name.


### PR DESCRIPTION
MacOS Catalina uses zsh by default, and for zsh `!` is an active character that swallows the following double quote character (in a double-quoted string). By changing the example to use a single-quoted string, the `!` is not active and the example becomes portable between zsh and bash. See issues #96 and #115.