### PR TITLE
Clarify wording about specifying variables for use with echo command

### DIFF
--- a/_episodes/03-working-with-files-and-folders.md
+++ b/_episodes/03-working-with-files-and-folders.md
@@ -337,11 +337,11 @@ $ ls
 {: .challenge}
 
 > ## Using the `echo` command
-> The `echo` command simply prints out a text you specify. Try it out: `echo "Library Carpentry is awesome!"`.
+> The `echo` command simply prints out a text you specify. Try it out: `echo "Library Carpentry is awesome"`.
 > Interesting, isn't it?
 >
-> You can also specify a variable, for instance `NAME=` followed by your name.
-> Then type `echo "$NAME is a fantastic library carpentry student"`. What happens?
+> You can also specify a variable. First type `NAME=` followed by your name, and hit enter.
+> Then type `echo "$NAME is a fantastic library carpentry student"` and hit enter. What happens?
 >
 > You can combine both text and normal shell commands using `echo`, for example the
 > `pwd` command you have learned earlier today. You do this by enclosing a shell


### PR DESCRIPTION
Revised wording about specifying variables within the echo command to make it more clear that it's a two-step process: (1) define the variable, and (2) reference the variable when using the echo command. Also removed exclamation mark from `echo "Library Carpentry is awesome!"` because I get the following error message when I include the exclamation mark: `-bash: !": event not found`. I don't get the error if I omit punctuation or use a period instead.