### PR TITLE
Normalize line endings in ep 6

### DIFF
--- a/_episodes/06-free-text.md
+++ b/_episodes/06-free-text.md
@@ -112,11 +112,12 @@ We now use the `tr` command, used for translating or
 deleting characters. Type and run:
 
 ~~~
-$ tr -d [:punct:] < gulliver-noheadfoot.txt > gulliver-noheadfootpunct.txt
+$ tr -d '[:punct:]\r' < gulliver-noheadfoot.txt > gulliver-noheadfootpunct.txt
 ~~~
 {: .bash}
 
-This uses the translate command and a special syntax to remove all punctuation.
+This uses the translate command and a special syntax to remove all punctuation
+(`[:punct:]`) and carriage returns (`\r`).
 It also requires the use of both the output redirect `>` we have seen and the input redirect `<` we haven't seen.
 
 Finally regularise the text by removing all the uppercase lettering.
@@ -325,11 +326,12 @@ We're going to start by using the `tr` command, used for translating or
 deleting characters. Type and run:
 
 ~~~
-$ tr -d [:punct:] < diary-notags.txt > diary-notagspunct.txt
+$ tr -d '[:punct:]\r' < diary-notags.txt > diary-notagspunct.txt
 ~~~
 {: .bash}
 
-This uses the translate command and a special syntax to remove all punctuation.
+This uses the translate command and a special syntax to remove all punctuation
+(`[:punct:]`) and carriage returns (`\r`).
 
 Finally regularise the text by removing all the uppercase lettering.
 


### PR DESCRIPTION
This seems like the easiest way to enforce UNIX line endings on UNIX platforms, without adding extra steps.

(On Windows, `\r` will already be stripped out by `sed`, but this shouldn't hurt.)

Closes #125.
