### PR TITLE
Remove out-of-date warning about grep -o

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -624,14 +624,6 @@ $ grep -iwEo 'fr[ae]nc[eh]' *.tsv
 ~~~
 {: .bash}
 
-> ## Invalid option -- o?
-> If you get an error message "invalid option -- o" when running the above command, it means you use a version of
-> `grep` that doesn't support the `-o` flag. This is for instance the case with the version of `grep` that comes with
-> Git Bash on Windows. Since the flag is not crucial to this lesson, please just relax and ignore the problem. If you
-> really needed the flag, however, you could have installed another version of `grep`. The situation for Windows users
-> also improves on Windows 10 with the new Bash on Windows.
-{: .callout}
-
 Pair up with your neighbor and work on these exercises:
 
 > ## Case sensitive search
@@ -733,8 +725,7 @@ Pair up with your neighbor and work on these exercises:
 > > correctly. You could use the `less` command for this.
 > >
 > > The `-o` flag means that only the ISSN itself is printed out, instead of the
-> > whole line. You can leave it out if it causes problems: see the callout box
-> > "Invalid option -- o?" above.
+> > whole line.
 > >
 > > If you came up with something more advanced, perhaps including word boundaries,
 > > please share your result in the collaborative document and give yourself a pat on the shoulder.
@@ -748,8 +739,6 @@ Pair up with your neighbor and work on these exercises:
 > In order for the 'uniq' command to only return unique values though, it needs to be used
 > with the 'sort' command. Try piping the output from the command in the last exercise
 > to `sort` and then piping these results to 'uniq' and then `wc -l` to count the number of unique ISSN values.
-> Note: This exercise requires the `-o` flag. See the callout box "Invalid option -- o?"
-> above.
 >
 > > ## Solution
 > > ~~~

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -12,9 +12,19 @@ ____
 Librarians like handouts. To make a handout for this lesson, adapt/print from [https://librarycarpentry.org/lc-shell/reference](https://librarycarpentry.org/lc-shell/reference).
 
 ______
-## 05-counting-mining.md
+## Differences between platforms
 
-This lesson notes that the `grep` flags `-o` and `-E` flag are not supported by Git Bash for Windows (see the callout 'Invalid option – o?'). Be prepared to manage these differences in shell behaviour between operating systems.
+Some of the commands used in this lesson behave differently depending on whether they are run on Git Bash for Windows, macOS X or Linux. Be prepared to manage these differences. Here are some examples from episode 5, "Counting and mining with the shell":
+
+- `grep -E` on macOS X acts like `grep -P` on other platforms. On Windows and Linux, `grep -E` is halfway between `grep -P` and `grep`: it only does what `grep` can do, but uses Perl-compatible syntax to do it.
+
+- The `grep` on Git Bash for Windows prior to version 2.19.0 (September 2018) did not support the `-o` flag. If someone gets an error "invalid option -- o", they are most likely trying to use one of these older versions. They should probably just skip the exercises that use it and upgrade later.
+
+- The episode uses `date +%Y-%m-%d` because `date -I` is not available on macOS X.
+
+- `date --help` is not available on macOS X so `man date` should be used instead.
+
+As noted below, you should avoid demonstrating any more options that only work on certain platforms.
 
 _____
 # General notes on shell
@@ -31,7 +41,7 @@ _____
         -   is hard to troubleshoot, review, or improve
 -   The Shell
     -   Workflows can be automated through the use of shell scripts
-    -   Built-in commands allow for easy data manipulation (e.g. sort, grep, etc.)
+    -   Built-in commands allow for easy data manipulation (e.g. `sort`, `grep`, etc.)
     -   Every step can be captured in the shell script and allow reproducibility and easy troubleshooting
 
 ## Overall
@@ -233,15 +243,7 @@ as long as learners using Windows do not run into roadblocks such as:
    Your particular shell may have extensions beyond POSIX that are not available
    on other machines, especially the default OSX bash and Windows bash emulators.
    For example, POSIX `ls` does not have an `--ignore=` or `-I` option, and POSIX
-   `head` takes `-n 10` or `-10`, but not the long form of `--lines=10`.  For example,
-   in Episode 5 when you are teaching grep there is a command in an exercise to prepend
-   dates to filenames that  will rely on the  `-I` option:
-      ~~~
-    $ grep -i revolution *.tsv > results/$(date -I)_JAi-revolution.tsv
-    ~~~
-    The `-I` option for ISO dates may not work with the date command on Mac OSX like it does from BSD through GNU. 
-    If you or your students are on a Mac and `-I` option isn't available, then you could mimic the `-I` option
-    like this:  `echo $(date +%Y-%m-%d)`
+   `head` takes `-n 10` or `-10`, but not the long form of `--lines=10`.
 
 
 ## Windows


### PR DESCRIPTION
Now `grep -o` is supported on all platforms, this PR removes the warning about it from episode 5 and adds an explanation of the issue to the instructor notes. Relates to #135.

Also updates the instructor notes in the light of other fixes related to platform differences.