### PR TITLE
Reduce teaching time for "what is the shell"

### DIFF
--- a/_episodes/01-intro-shell.md
+++ b/_episodes/01-intro-shell.md
@@ -1,6 +1,6 @@
 ---
 title: "What is the shell?"
-teaching: 20
+teaching: 5
 exercises: 0
 questions:
 - "What is the shell?"


### PR DESCRIPTION
The current teaching length of 20 minutes is inaccurate and much longer than this episode takes. I'm proposing 5 minutes as it is similar to the SWC lesson (http://swcarpentry.github.io/shell-novice/01-intro/index.html), but it could be adjusted up to 10 minutes as well.
