### PR TITLE
Fix bash formatting on exercise solution

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -323,8 +323,8 @@ programming languages.
 > >~~~
 > > wc -w *.tsv | sort -n | tail -n 11
 > >~~~
+> >{: .bash}
 > {: .solution}
->{: .bash}
 {: .challenge}
 
 


### PR DESCRIPTION
Fixes the bash formatting issue in the counting and mining episode, which is causing a display issue near the solution section:

![Screen Shot 2020-08-19 at 5 05 17 PM](https://user-images.githubusercontent.com/6903515/90689562-457ea980-e23e-11ea-8ddc-b5802c25e59c.png)
