### PR TITLE
Getting rid of Part I to go with PR 148

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -328,7 +328,7 @@ programming languages.
 {: .challenge}
 
 
-> ## Counting number of files, part I
+> ## Counting number of files
 > Let's make a different pipeline. You want to find out how many files and
 > directories there are in the current directory. Try to see if you can pipe
 > the output from `ls` into `wc` to find the answer, or something close to the


### PR DESCRIPTION
I just submitted a pull request for changing the counting the number of files part I and II excercises, and since that pull request eliminated the part II excercise, the part I is now no longer necessary.

