### PR TITLE
?.txt instead of *.txt for loop example

### DIFF
--- a/_episodes/04-loops.md
+++ b/_episodes/04-loops.md
@@ -45,7 +45,7 @@ We can apply this to our example like this:
 
 
 ~~~
-$ for filename in *.txt
+$ for filename in ?.txt
 > do
 >    echo "$filename"
 >    cp "$filename" backup_"$filename"


### PR DESCRIPTION
The lesson was changed from using the touch command to create .doc files to .txt files, but since there are also a number of other .txt files in this directory, when you run the loop it changes all the .txt files, not just the newly created ones: a.txt b.txt c.txt d.txt. To make is so the loop only changes the newly created .txt files, you need to write the code in the loop as ?.txt and not *.txt. This will give you the correct output. This example could be created outside the shell-lesson directory, but learners could also have .txt files there too. If we don't want to use the ?.txt, then we could go back to creating .doc files for this example.

