### PR TITLE
propose to add single quotes in example in 06-free-text.md

### DIFF
--- a/_episodes/06-free-text.md
+++ b/_episodes/06-free-text.md
@@ -123,7 +123,7 @@ It also requires the use of both the output redirect `>` we have seen and the in
 Finally regularise the text by removing all the uppercase lettering.
 
 ~~~
-$ tr [:upper:] [:lower:] < gulliver-noheadfootpunct.txt > gulliver-clean.txt
+$ tr '[:upper:]' '[:lower:]' < gulliver-noheadfootpunct.txt > gulliver-clean.txt
 ~~~
 {: .bash}
 


### PR DESCRIPTION
As I'm working through this lesson (on MacOS zsh shell), this command doesn't work unless I surround the string1 and string2 with single quotes. Has anyone else noted this? It seems that perhaps these should be added in this example? Or perhaps it is a difference between Mac and Windows? Thanks!
