### PR TITLE
Clarify phrasing

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -755,7 +755,7 @@ We will now use a loop to automate the counting of certain words within a docume
 $ mv pg514.txt littlewomen.txt
 ~~~
 
-This renames the file to something easier to type.
+This renames the file to something easier to memorize.
 
 Now let's create our loop. In the loop, we will ask the computer to go through the text, looking for each girl's name,
 and count the number of times it appears. The results will print to the screen.


### PR DESCRIPTION
This is rather nitpicking but I stumbled over it when preparing for my teaching demo.

"pg514.txt" is arguably easier/quicker to type than "littlewomen.txt"
but the second is easier to memorize and thus does not have to be
looked up for typing it.
