### PR TITLE
Remove ref to macOS not having `date -I`

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -531,7 +531,7 @@ $ grep -i revolution *.tsv > results/$(date "+%Y-%m-%d")_JAi-revolution.tsv
 This saves the subsetted data to a new file.
 
 > ## Alternative date commands
-> This way of writing dates is so common that on some platforms (not macOS X)
+> This way of writing dates is so common that on some platforms
 > you can get the same result by typing `$(date -I)` instead of
 > `$(date "+%Y-%m-%d")`.
 {: .callout}


### PR DESCRIPTION
The `-I` option was added to the FreeBSD version of `date` in FreeBSD 12.0, and is therefore available in newer versions of macOS (I *think* since macOS 12 Monterey).
