### PR TITLE
Remove ref to macOS not having `date -I`

### DIFF
--- a/episodes/05-counting-mining.md
+++ b/episodes/05-counting-mining.md
@@ -564,7 +564,7 @@ This saves the subsetted data to a new file.
 
 ## Alternative date commands
 
-This way of writing dates is so common that on some platforms (not macOS X)
+This way of writing dates is so common that on some platforms
 you can get the same result by typing `$(date -I)` instead of
 `$(date "+%Y-%m-%d")`.
 

--- a/episodes/05-counting-mining.md
+++ b/episodes/05-counting-mining.md
@@ -564,7 +564,7 @@ This saves the subsetted data to a new file.
 
 ## Alternative date commands
 
-This way of writing dates is so common that on some platforms
+This way of writing dates is so common that on most platforms
 you can get the same result by typing `$(date -I)` instead of
 `$(date "+%Y-%m-%d")`.
 


### PR DESCRIPTION
The `-I` option was added to the FreeBSD version of `date` in FreeBSD 12.0, and is therefore available in newer versions of macOS. While technically it is true that this option is not in MacOS X and possibly macOS 11 (Big Sur), it may cause confusion to highlight it when most learners on macOS will have a version that supports the option.

Recreates auto-closed PR #217.
