### PR TITLE
Remove broken/deprecated Gitter link

### DIFF
--- a/learners/discuss.md
+++ b/learners/discuss.md
@@ -4,10 +4,7 @@ title: Discussion
 
 There are many ways to discuss Library Carpentry lessons:
 
-- Join our [Gitter discussion forum](https://gitter.im/LibraryCarpentry/).
 - Join our [Slack organisation](https://swc-slack-invite.herokuapp.com/) and #libraries channel.
 - Stay in touch with our [Topicbox Group](https://carpentries.topicbox.com/groups/discuss-library-carpentry).
 - Follow updates on [Twitter](https://twitter.com/LibCarpentry).
 - Make a suggestion or correct an error by [raising an Issue](https://github.com/LibraryCarpentry/lc-shell/issues) or [submit a pull request](https://github.com/LibraryCarpentry/lc-shell/pulls).
-
-


### PR DESCRIPTION
Removes broken Gitter link, which is also now deprecated in favour of Slack.