### PR TITLE
remove period from line with bash command

### DIFF
--- a/episodes/02-navigating-the-filesystem.md
+++ b/episodes/02-navigating-the-filesystem.md
@@ -122,7 +122,7 @@ us right back to the home directory, the place where we started.**
 
 ## Previous Directory
 
-To switch back and forth between two directories use `cd -`.
+To switch back and forth between two directories use `cd -`
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
This removes the period from the line demonstrating `cd -` because it makes it look like it is part of the command and can be confusing. Since this is a standalone line, the period may not be necessary for the syntax of the sentence.