### PR TITLE
Format ref page#246

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -25,9 +25,7 @@ title: Reference
 **`cd`** - change directory
 
 - `cd pathname` - take you to the directory specified by `pathname`
-
 - `cd ~` -  take you to your home directory
-
 - `cd ..` - take you up one directory
 
 ***

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -22,7 +22,7 @@ title: Reference
 - `ls -a` - list all files, including hidden files
 - `ls *.txt` - list all files that end with `.txt`
 
-**`cd`** change directory
+**`cd`** - change directory
 
 - `cd pathname` - take you to the directory specified by `pathname`
 

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -85,7 +85,7 @@ title: Reference
 - `wc -l` - count lines
 - `wc -c` - count characters
 
-**sort** - sort input (alphabetic sorting)
+**`sort`** - sort input (alphabetic sorting)
 
 - `sort -n` - sort input numerically
 

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -34,7 +34,7 @@ title: Reference
 
 ### Shell: Interacting with Files
 
-**`mkdir`** - make a directory.
+**`mkdir`** - make a directory
 
 **`cat`** - print to shell or send file or files to output
 

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -12,7 +12,7 @@ title: Reference
 
 **`man`** - display the user manual
 
-**`history`** - displays the history list with line numbers, use `n` to limit the list
+**`history`** - display the history list with line numbers, use `n` to limit the list
 
 **`ls`** - list contents of a directory
 
@@ -66,14 +66,14 @@ title: Reference
 
 **`*`** - a placeholder for zero or more characters or numbers
 
-**`[]`** - defines a class of characters
+**`[]`** - define a class of characters
 
 *Examples*
 
-- `foobar?` - matches 7-character strings starting with `foobar` and ending with one character or number
-- `foobar*` - matches strings that start with `foobar` and end with zero or more other characters or numbers
-- `foobar*txt` - matches strings that start with `foobar` and end with `txt`
-- `[1-9]foobar?` - matches 8-character strings that start that start with a number, have `foobar` after the number, and end with any character or number
+- `foobar?` - match 7-character strings starting with `foobar` and ending with one character or number
+- `foobar*` - match strings that start with `foobar` and end with zero or more other characters or numbers
+- `foobar*txt` - match strings that start with `foobar` and end with `txt`
+- `[1-9]foobar?` - match 8-character strings that start that start with a number, have `foobar` after the number, and end with any character or number
 
 ***
 
@@ -91,7 +91,7 @@ title: Reference
 
 **`grep`** - global regular expression print
 
-- `grep -c` - displays counts of matches for each file
+- `grep -c` - display counts of matches for each file
 - `grep -i` - match with case insensitivity
 - `grep -w` - match whole words
 - `grep -v` - exclude match

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -36,7 +36,7 @@ title: Reference
 
 **`mkdir`** - make a directory.
 
-**`cat`** - print to shell or send file or files to output.`
+**`cat`** - print to shell or send file or files to output
 
 **`head`** - output first 10 lines of a file or files
 

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -24,92 +24,98 @@ title: Reference
 
 **`cd`** change directory
 
-`cd pathname` - takes you to the directory specified by `pathname`
+- `cd pathname` - take you to the directory specified by `pathname`
 
-`cd ~` -  takes you to your home directory
+- `cd ~` -  take you to your home directory
 
-`cd ..` - takes you up one directory
+- `cd ..` - take you up one directory
 
 ***
 
 ### Shell: Interacting with Files
 
-**`mkdir`** make a directory
+**`mkdir`** - make a directory.
 
-**`cat`** print to shell or send file or files to output
+**`cat`** - print to shell or send file or files to output.`
 
-**`head`** output first 10 lines of a file or files
+**`head`** - output first 10 lines of a file or files
 
-**`tail`** output last 10 lines of a file or files
+**`tail`** - output last 10 lines of a file or files
 
-**`mv`** rename or move a file or files. Syntax for renaming a file: `mv FILENAME NEWFILENAME`
+**`mv`** - rename or move a file or files. Syntax for renaming a file: `mv FILENAME NEWFILENAME`
 
-**`cp`** make a backup copy of a file or files. Syntax: `cp FILENAME NEWFILENAME`
+**`cp`** - make a backup copy of a file or files. Syntax: `cp FILENAME NEWFILENAME`
 
-**`>`** redirect output. Syntax with `cat`: `cat FILENAME1 FILENAME2 > NEWFILENAME`
+**`>`** - redirect output. Syntax with `cat`: `cat FILENAME1 FILENAME2 > NEWFILENAME`
 
-**`>>`** redirect output by appending to the filename specified. Syntax with `cat`: `cat FILENAME1 FILENAME2 >> NEWFILENAME`
+**`>>`** - redirect output by appending to the filename specified. Syntax with `cat`: `cat FILENAME1 FILENAME2 >> NEWFILENAME`
 
-**`rm`** remove a file or files. NB: *USE WITH EXTREME CAUTION!!!*
+**`rm`** - remove a file or files. NB: *USE WITH EXTREME CAUTION!!!*
 
-**`rmdir -r`** will delete a directory, even if it is not empty.
+- `rm -ri` - delete a directory, even if it is not empty, but will ask you to confirm each deletion
 
-**`rm -ri`** will delete a directory, even if it is not empty, but will ask you to confirm each deletion.
+**`rmdir -r`** - delete a directory, even if it is not empty
 
-**`touch`** will update timestamp information on files, or create a file or files if they don't exist.
+**`touch`** - update timestamp information on files, or create a file or files if they don't exist
 
 ***
 
 ### Shell: Wildcards
 
-**`?`** a placeholder for one character or number
+**`?`** - a placeholder for one character or number
 
-**`*`** a placeholder for zero or more characters or numbers
+**`*`** - a placeholder for zero or more characters or numbers
 
-**`[]`** defines a class of characters
+**`[]`** - defines a class of characters
 
 *Examples*
 
-- `foobar?`: matches 7-character strings starting with `foobar` and ending with one character or number
-- `foobar*`: matches strings that start with `foobar` and end with zero or more other characters or numbers
-- `foobar*txt`: matches strings that start with `foobar` and end with `txt`
-- `[1-9]foobar?`: matches 8-character strings that start that start with a number, have `foobar` after the number, and end with any character or number.
+- `foobar?` - matches 7-character strings starting with `foobar` and ending with one character or number
+- `foobar*` - matches strings that start with `foobar` and end with zero or more other characters or numbers
+- `foobar*txt` - matches strings that start with `foobar` and end with `txt`
+- `[1-9]foobar?` - matches 8-character strings that start that start with a number, have `foobar` after the number, and end with any character or number
 
 ***
 
 ### Shell: Counting and Mining
 
-**`wc`** word count
+**`wc`** - word count
 
-- `-w`: count words
-- `-l`: count lines
-- `-c`: count characters
+- `wc -w` - count words
+- `wc -l` - count lines
+- `wc -c` - count characters
 
-**sort** sort input
+**sort** - sort input (alphabetic sorting)
 
-**`grep`** global regular expression print
+- `sort -n` - sort input numerically
 
-- `-c`: displays counts of matches for each file
-- `-i`: match with case insensitivity
-- `-w`: match whole words
-- `-v`: exclude match
-- `--file=FILENAME.txt`: use the file `FILENAME.txt` as the source of strings used in query
-- `|`: (vertical bar character) send output from one command into another command
+**`grep`** - global regular expression print
+
+- `grep -c` - displays counts of matches for each file
+- `grep -i` - match with case insensitivity
+- `grep -w` - match whole words
+- `grep -v` - exclude match
+- `grep --file=FILENAME.txt` - use the file `FILENAME.txt` as the source of strings used in query
+
+**`|`** - (vertical bar character) send output from one command into another command. 
+Example: `wc -l *.txt | sort -n`
 
 ***
 
 ### Shell: Working with Free Text
 
-**`sed`** is used to modify files, use `-e` flag to run multiple commands
+**`sed`** - is used to modify files
+- `sed -e` - run multiple commands
 
-**`tr`** translates or deletes characters in a file
+**`tr`** - translates or deletes characters in a file. Some allowed sequences:
 
-- `[:punct:]`: punctuation characters
-- `[:upper:]`: upper-case characters
-- `[:lower:]`: lower-case alphabetic characters
+- `[:punct:]` - punctuation characters
+- `[:upper:]` - upper-case characters
+- `[:lower:]` - lower-case alphabetic characters
 
-**`'''\n`** translates every blank space into `\n`, then renders on a new line
+Example: `tr '''\n` - translate every blank space into `\n`, then renders on a new line
 
-**`uniq`** reports or filters repeated lines in a file, use with `-c` to do a word count of the duplicates
+**`uniq`** - report or filters repeated lines in a file
+- `uniq -c`- do a word count of the duplicates
 
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Closes #246 

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

I have modified the file `learners/reference.md` to harmonise the format as it was requested in the ticket. In addition I performed small modifications. The changes I performed can be summarised here:
1. After each command is defined in the references, there is always "-" symbol
2. All the verbs after the command/wildcard are in infinitive and not third-person
3. When flags are explained, I put always the command before the flag being consistent with the first "ls" example
4. Vertical bar character is not a flag of grep command and I added a separated command. I added also a small example using previous commands
5. I added a flag for the sort command as its normal behaviour is sorting using alphabetic characters

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>

